### PR TITLE
specify public release in npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,3 +30,4 @@ jobs:
         uses: JS-DevTools/npm-publish@v3
         with:
           token: ${{ secrets.NPM_TOKEN }}
+          access: public


### PR DESCRIPTION
For the initial release, it looks like you have to specify that the package should be public. I will delete the first release and try again.