### PR TITLE
Adding External Adapter Support

### DIFF
--- a/main/contracts/contracts.ts
+++ b/main/contracts/contracts.ts
@@ -96,6 +96,23 @@ export interface IMessageBroker<T> {
      * This RSVP function is used by responders and is analogous to the 'Get' function. Responders when invoked must return the required response value type.
      */
     rsvp<K extends keyof RSVPOf<T>>(channelName: K, handler: RSVPHandler<T>): IResponderRef;
+
+    /**
+     * Register an adapter with the message broker
+     * @param adapter The adapter to register
+     */
+    registerAdapter(adapter: IMessageBrokerAdapter<T>): void;
+
+    /**
+     * Unregister an adapter from the message broker
+     * @param adapterId The ID of the adapter to unregister
+     */
+    unregisterAdapter(adapterId: string): void;
+
+    /**
+     * Get all registered adapters
+     */
+    getAdapters(): IMessageBrokerAdapter<T>[];
 }
 
 /**
@@ -148,4 +165,45 @@ export interface IResponderRef {
      * Disconnect allows the responder to be disconnected from the list of available responders.
      */
     disconnect: () => void;
+}
+
+/**
+ * Base interface for message broker adapters that integrate with external messaging systems
+ */
+export interface IMessageBrokerAdapter<T> {
+    /**
+     * Unique identifier for the adapter
+     */
+    readonly id: string;
+    
+    /**
+     * Initialize the adapter
+     */
+    initialize(): Promise<void>;
+    
+    /**
+     * Connect to the external messaging system
+     */
+    connect(): Promise<void>;
+    
+    /**
+     * Disconnect from the external messaging system
+     */
+    disconnect(): Promise<void>;
+    
+    /**
+     * Send a message to the external system
+     */
+    sendMessage(channelName: keyof T, message: IMessage): Promise<void>;
+    
+    /**
+     * Subscribe to messages from the external system
+     * Returns an observable of messages received from external system
+     */
+    subscribeToMessages(channelName: keyof T): Observable<IMessage<T[any]>>;
+    
+    /**
+     * Check if the adapter is connected
+     */
+    isConnected(): boolean;
 }

--- a/main/contracts/contracts.ts
+++ b/main/contracts/contracts.ts
@@ -113,6 +113,11 @@ export interface IMessageBroker<T> {
      * Get all registered adapters
      */
     getAdapters(): IMessageBrokerAdapter<T>[];
+
+    /**
+     * Get error stream for adapter failures
+     */
+    getErrorStream(): Observable<IAdapterError<T>>;
 }
 
 /**
@@ -175,35 +180,69 @@ export interface IMessageBrokerAdapter<T> {
      * Unique identifier for the adapter
      */
     readonly id: string;
-    
+
     /**
      * Initialize the adapter
+     * Returns an observable that completes when initialization is done
      */
-    initialize(): Promise<void>;
-    
+    initialize(): Observable<void>;
+
     /**
      * Connect to the external messaging system
+     * Returns an observable that completes when connection is established
      */
-    connect(): Promise<void>;
-    
+    connect(): Observable<void>;
+
     /**
      * Disconnect from the external messaging system
+     * Returns an observable that completes when disconnection is done
      */
-    disconnect(): Promise<void>;
-    
+    disconnect(): Observable<void>;
+
     /**
      * Send a message to the external system
+     * Returns an observable that completes when message is sent
      */
-    sendMessage(channelName: keyof T, message: IMessage): Promise<void>;
-    
+    sendMessage(channelName: keyof T, message: IMessage): Observable<void>;
+
     /**
      * Subscribe to messages from the external system
      * Returns an observable of messages received from external system
      */
     subscribeToMessages(channelName: keyof T): Observable<IMessage<T[any]>>;
-    
+
     /**
      * Check if the adapter is connected
      */
     isConnected(): boolean;
+}
+
+/**
+ * Error information for adapter failures
+ */
+export interface IAdapterError<T> {
+    /**
+     * The adapter that failed
+     */
+    adapterId: string;
+
+    /**
+     * The channel name where the error occurred
+     */
+    channelName: keyof T;
+
+    /**
+     * The message that failed to send
+     */
+    message: IMessage;
+
+    /**
+     * The error that occurred
+     */
+    error: Error;
+
+    /**
+     * Timestamp when the error occurred
+     */
+    timestamp: number;
 }

--- a/main/index.ts
+++ b/main/index.ts
@@ -11,4 +11,5 @@ export {
     RSVPHandler,
     RSVPResponse,
     IMessageBrokerAdapter,
+    IAdapterError,
 } from './contracts/contracts';

--- a/main/index.ts
+++ b/main/index.ts
@@ -10,4 +10,5 @@ export {
     RSVPPayload,
     RSVPHandler,
     RSVPResponse,
+    IMessageBrokerAdapter,
 } from './contracts/contracts';

--- a/spec/core/messagebroker-adapter.spec.ts
+++ b/spec/core/messagebroker-adapter.spec.ts
@@ -1,0 +1,155 @@
+
+import { IMocked, Mock, setupFunction } from '@morgan-stanley/ts-mocking-bird';
+import { Observable, Subject } from 'rxjs';
+import { MessageBroker } from '../../main/core/messagebroker';
+import { RSVPMediator } from '../../main/core/rsvp-mediator';
+import { IMessage, IMessageBroker, IMessageBrokerAdapter } from '../../main/contracts/contracts';
+
+interface ITestChannels {
+    'test-channel': {
+        test: string;
+    };
+    'external-channel': {
+        external: string;
+    };
+}
+
+class MockAdapter implements IMessageBrokerAdapter<ITestChannels> {
+    public readonly id: string = 'mock-adapter';
+    
+    private connected: boolean = false;
+    private messageSubjects: Map<string, Subject<IMessage>> = new Map();
+    public sentMessages: Array<{ channel: keyof ITestChannels; message: IMessage }> = [];
+
+    async initialize(): Promise<void> {}
+
+    async connect(): Promise<void> {
+        this.connected = true;
+    }
+
+    async disconnect(): Promise<void> {
+        this.connected = false;
+        this.messageSubjects.clear();
+    }
+
+    async sendMessage(channelName: keyof ITestChannels, message: IMessage): Promise<void> {
+        if (this.connected) {
+            this.sentMessages.push({ channel: channelName, message });
+        }
+    }
+
+    subscribeToMessages(channelName: keyof ITestChannels): Observable<IMessage> {
+        if (!this.messageSubjects.has(channelName)) {
+            this.messageSubjects.set(channelName, new Subject<IMessage>());
+        }
+        return this.messageSubjects.get(channelName)!.asObservable();
+    }
+
+    isConnected(): boolean {
+        return this.connected;
+    }
+
+    public simulateIncomingMessage(channelName: keyof ITestChannels, message: IMessage): void {
+        const subject = this.messageSubjects.get(channelName);
+        if (subject) {
+            subject.next(message);
+        }
+    }
+}
+
+describe('MessageBroker Adapter', () => {
+    let broker: IMessageBroker<ITestChannels>;
+    let mockRSVPMediator: IMocked<RSVPMediator<ITestChannels>>
+    let mockAdapter: MockAdapter;
+
+    beforeEach(() => {
+        mockRSVPMediator = Mock.create<RSVPMediator<ITestChannels>>().setup(setupFunction('rsvp'));
+        broker = getInstance<ITestChannels>();
+        mockAdapter = new MockAdapter();
+    });
+
+    function getInstance<T>(): IMessageBroker<T> {
+        return new MessageBroker<T>(mockRSVPMediator.mock);
+    }
+
+    it('should register adapter successfully', () => {
+        broker.registerAdapter(mockAdapter);
+        
+        const adapters = broker.getAdapters();
+        expect(adapters).toContain(mockAdapter);
+        expect(adapters.length).toBe(1);
+    });
+
+    it('should unregister adapter successfully', () => {
+        broker.registerAdapter(mockAdapter);
+        broker.unregisterAdapter(mockAdapter.id);
+        
+        const adapters = broker.getAdapters();
+        expect(adapters.length).toBe(0);
+    });
+
+    it('should initialize and connect adapter', async () => {
+        await mockAdapter.initialize();
+        await mockAdapter.connect();
+        
+        expect(mockAdapter.isConnected()).toBe(true);
+    });
+
+    it('should send messages to connected adapter', async () => {
+        await mockAdapter.initialize();
+        await mockAdapter.connect();
+        broker.registerAdapter(mockAdapter);
+
+        broker.create('test-channel').publish({ test: 'data' });
+
+        expect(mockAdapter.sentMessages.length).toBe(1);
+        expect(mockAdapter.sentMessages[0].channel).toBe('test-channel');
+        expect(mockAdapter.sentMessages[0].message.data).toEqual({ test: 'data' });
+    });
+
+    it('should receive messages from adapter subscription', async () => {
+        await mockAdapter.initialize();
+        await mockAdapter.connect();
+        broker.registerAdapter(mockAdapter);
+        
+        const messagePromise = new Promise<void>((resolve) => {
+            broker.get('test-channel').subscribe((message) => {
+                expect(message.data).toEqual({ test: 'external-data' });
+                resolve();
+            });
+        });
+
+        const externalMessage: IMessage = {
+            channelName: 'test-channel',
+            data: { test: 'external-data' },
+            timestamp: Date.now(),
+            id: 'external-id',
+            isHandled: false
+        };
+
+        mockAdapter.simulateIncomingMessage('test-channel', externalMessage);
+        
+        await messagePromise;
+    });
+
+    it('should not send messages to disconnected adapter', async () => {
+        await mockAdapter.initialize();
+        await mockAdapter.connect();
+        await mockAdapter.disconnect();
+
+        broker.create('test-channel').publish({ test: 'data' });
+
+        expect(mockAdapter.sentMessages.length).toBe(0);
+    });
+
+    it('should disconnect and clear message subjects', async () => {
+        await mockAdapter.initialize();
+        await mockAdapter.connect();
+        
+        broker.get('test-channel').subscribe();
+        
+        await mockAdapter.disconnect();
+        
+        expect(mockAdapter.isConnected()).toBe(false);
+    });
+});


### PR DESCRIPTION
This PR introduces a new interface for plugging in adapters to the message broker. This will allow users to create an adapter which can connect to an external system and send messages to it, or receive messages from it. The adapter can be given to the messagebroker on startup, and then users of the messagebroker won't even know it's there.

The original design in the issue used Promises as the return types of some of the functions, e.g. `connect(): Promise<void>`, in order to keep the library consistent on how it handles async behavior, I've tried changing this to use observables instead: `connect(): Observable<void>`. This has the downside of not being compatible with async/await though. I'm curious to hear your thoughts on this.

Another change from the design in the issue, is the addition of an error stream. Given we're connecting with an external system, it's likely there will be some unexpected failures. I wasn't sure what the best way to handle that would be, so I've introduced this dedicated error stream that can be subscribed to so that the app can do something with them. Again, I'd like some feedback on that.