### PR TITLE
ci(release): remove npm token env variable for trusted publishers, update to Node 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [18.x, 20.x, 21.x]
+                node-version: [20.x, 22.x, 24.x]
 
         steps:
             - uses: actions/checkout@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24'
 
       - name: Install node modules and verify build
         run: npm install && npm run build-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,16 @@ on:
     types: [ published ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write    
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -27,7 +33,4 @@ jobs:
         run: npm run lint && npm run test
 
       - name: Publish
-        uses: JS-DevTools/npm-publish@v3
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
-          access: public
+        run: npm publish --provenance --access public


### PR DESCRIPTION
Replace explicit NPM_TOKEN environment variable with OIDC-based trusted publishing for enhanced security and simplified token management.