### PR TITLE
Add codeql-action grouping to github-actions dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,3 +33,7 @@ updates:
       directory: '/'
       schedule:
           interval: 'weekly'
+      groups:
+          codeql-actions:
+              patterns:
+                  - 'github/codeql-action/*'


### PR DESCRIPTION
Groups `github/codeql-action/*` updates together in the `github-actions` dependabot ecosystem so CodeQL action version bumps are batched into a single PR instead of one per component action.